### PR TITLE
Duplicate rule names

### DIFF
--- a/d3-cli/pyproject.toml
+++ b/d3-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "d3-cli"
-version = "0.1.8"
+version = "0.1.9"
 description = "Utility scripts for ManySecured-D3 claims"
 authors = [
     "NquiringMinds <contact@nquiringminds.com>",

--- a/d3-cli/src/d3_scripts/resolve_behaviour_rules.py
+++ b/d3-cli/src/d3_scripts/resolve_behaviour_rules.py
@@ -4,6 +4,10 @@ from iteration_utilities import unique_everseen
 from typing import List, Dict
 
 
+def get_item(collection, key, target):
+    return next((item for item in collection if item.get(key, None) == target), None)
+
+
 def resolve_behaviour_rules(
     claim: BehaviourJson, claim_map: BehaviourMap, claim_graph: nx.DiGraph
 ) -> List[Dict]:
@@ -28,9 +32,13 @@ def resolve_behaviour_rules(
         try:
             parent_claim = claim_map[parent_id]
         except KeyError:
-            raise KeyError(f"Parent behaviour id {parent_id} of {id} doesn't exist")
+            raise KeyError(
+                f"Parent behaviour id {parent_id} of {id} doesn't exist")
         parent_rules = parent_claim["credentialSubject"].get("rules", [])
-        aggregated_rules += parent_rules
+        for rule in parent_rules:
+            if get_item(aggregated_rules, "ruleName", rule["ruleName"]):
+                rule["ruleName"] = f"{parent_claim['credentialSubject']['ruleName']}/{rule['ruleName']}"
+            aggregated_rules.append(rule)
     unique_aggregated_rules = list(
         unique_everseen(aggregated_rules)
     )  # De-duplicate any duplicate rules

--- a/d3-cli/src/d3_scripts/resolve_behaviour_rules.py
+++ b/d3-cli/src/d3_scripts/resolve_behaviour_rules.py
@@ -4,11 +4,11 @@ from iteration_utilities import unique_everseen
 from typing import List, Dict
 
 
-def get_item(collection: List[Dict], key: str, target: str or int or float):
+def _get_item(collection: List[Dict], key: str, target: str or int or float):
     """
     Get item in collection (array of dictionaries) by key and target value, if a match exists.
 
-    E.g. get_item([{"name": "Bob"}, {"name": "Alice"}, {"name": "Carl"}, {"name": "Dobby"}], "name", "Alice")
+    E.g. _get_item([{"name": "Bob"}, {"name": "Alice"}, {"name": "Carl"}, {"name": "Dobby"}], "name", "Alice")
     will return the {"name": "Alice"} dictionary. If no matches exist, function will return None.
 
     Args:
@@ -50,7 +50,7 @@ def resolve_behaviour_rules(
                 f"Parent behaviour id {parent_id} of {id} doesn't exist")
         parent_rules = parent_claim["credentialSubject"].get("rules", [])
         for rule in parent_rules:
-            if get_item(aggregated_rules, "ruleName", rule["ruleName"]):
+            if _get_item(aggregated_rules, "ruleName", rule["ruleName"]):
                 rule["ruleName"] = f"{parent_claim['credentialSubject']['ruleName']}/{rule['ruleName']}"
             aggregated_rules.append(rule)
     unique_aggregated_rules = list(

--- a/d3-cli/src/d3_scripts/resolve_behaviour_rules.py
+++ b/d3-cli/src/d3_scripts/resolve_behaviour_rules.py
@@ -4,7 +4,21 @@ from iteration_utilities import unique_everseen
 from typing import List, Dict
 
 
-def get_item(collection, key, target):
+def get_item(collection: List[Dict], key: str, target: str or int or float):
+    """
+    Get item in collection (array of dictionaries) by key and target value, if a match exists.
+
+    E.g. get_item([{"name": "Bob"}, {"name": "Alice"}, {"name": "Carl"}, {"name": "Dobby"}], "name", "Alice")
+    will return the {"name": "Alice"} dictionary. If no matches exist, function will return None.
+
+    Args:
+        collection: Array of dictionaries
+        key: Key in dictionary to match against
+        target: Target value to match against
+
+    Returns:
+        Matching Dictionary
+    """
     return next((item for item in collection if item.get(key, None) == target), None)
 
 

--- a/d3-cli/src/d3_scripts/schemas/behaviour.json
+++ b/d3-cli/src/d3_scripts/schemas/behaviour.json
@@ -25,7 +25,7 @@
         "type": "object",
         "required": ["matches"],
         "properties": {
-          "name": {
+          "ruleName": {
             "type": "string",
             "description": "Name of the rule"
           },

--- a/d3-cli/tests/__fixtures__/d3-build/behaviour-1.behaviour.d3.yaml
+++ b/d3-cli/tests/__fixtures__/d3-build/behaviour-1.behaviour.d3.yaml
@@ -3,7 +3,7 @@ credentialSubject:
   id: aa92ebae-4928-4456-b597-cbd7657e9e83
   ruleName: Behaviour 1
   rules:
-    - name: rule no. 1
+    - ruleName: rule no. 1
       matches:
         ip4:
           protocol: 1

--- a/d3-cli/tests/__fixtures__/d3-build/behaviour-2.behaviour.d3.yaml
+++ b/d3-cli/tests/__fixtures__/d3-build/behaviour-2.behaviour.d3.yaml
@@ -3,7 +3,7 @@ credentialSubject:
   id: a86aa19f-a81d-4624-b290-436172a8db1c
   ruleName: Behaviour 2
   rules:
-    - name: rule no. 1
+    - ruleName: rule no. 1
       matches:
         ip4:
           protocol: 2

--- a/d3-cli/tests/__fixtures__/d3-build/behaviour-4.behaviour.d3.yaml
+++ b/d3-cli/tests/__fixtures__/d3-build/behaviour-4.behaviour.d3.yaml
@@ -5,7 +5,7 @@ credentialSubject:
   parents:
     - 35294a50-4262-4bac-9d89-10e31e13b4cf
   rules:
-    - name: rule no. 2
+    - ruleName: rule no. 2
       matches:
         ip4:
           protocol: 1

--- a/d3-cli/tests/__fixtures__/inherited-rulename-conflict/behaviour-1.behaviour.d3.yaml
+++ b/d3-cli/tests/__fixtures__/inherited-rulename-conflict/behaviour-1.behaviour.d3.yaml
@@ -1,0 +1,11 @@
+type: d3-device-type-behaviour
+credentialSubject:
+  id: aa92ebae-4928-4456-b597-cbd7657e9e83
+  ruleName: Behaviour 1
+  rules:
+    - name: rule no. 1
+      matches:
+        ip4:
+          protocol: 1
+        tcp:
+          destinationPort: 1

--- a/d3-cli/tests/__fixtures__/inherited-rulename-conflict/behaviour-1.behaviour.d3.yaml
+++ b/d3-cli/tests/__fixtures__/inherited-rulename-conflict/behaviour-1.behaviour.d3.yaml
@@ -3,7 +3,7 @@ credentialSubject:
   id: aa92ebae-4928-4456-b597-cbd7657e9e83
   ruleName: Behaviour 1
   rules:
-    - name: rule no. 1
+    - ruleName: rule no. 1
       matches:
         ip4:
           protocol: 1

--- a/d3-cli/tests/__fixtures__/inherited-rulename-conflict/behaviour-2.behaviour.d3.yaml
+++ b/d3-cli/tests/__fixtures__/inherited-rulename-conflict/behaviour-2.behaviour.d3.yaml
@@ -1,0 +1,13 @@
+type: d3-device-type-behaviour
+credentialSubject:
+  id: a86aa19f-a81d-4624-b290-436172a8db1c
+  ruleName: Behaviour 2
+  parents:
+    - aa92ebae-4928-4456-b597-cbd7657e9e83
+  rules:
+    - name: rule no. 1
+      matches:
+        ip4:
+          protocol: 2
+        tcp:
+          destinationPort: 2

--- a/d3-cli/tests/__fixtures__/inherited-rulename-conflict/behaviour-2.behaviour.d3.yaml
+++ b/d3-cli/tests/__fixtures__/inherited-rulename-conflict/behaviour-2.behaviour.d3.yaml
@@ -5,7 +5,7 @@ credentialSubject:
   parents:
     - aa92ebae-4928-4456-b597-cbd7657e9e83
   rules:
-    - name: rule no. 1
+    - ruleName: rule no. 1
       matches:
         ip4:
           protocol: 2

--- a/d3-cli/tests/__fixtures__/inherited-rulename-conflict/device-2.type.d3.yaml
+++ b/d3-cli/tests/__fixtures__/inherited-rulename-conflict/device-2.type.d3.yaml
@@ -1,0 +1,9 @@
+credentialSubject:
+  id: 0de372d6-4ccc-46d3-a1ce-eb73e89b9b74
+  macAddresses:
+  - C5-5E-87-89-3C-3B
+  manufacturer: NquiringMinds
+  manufacturerUri: https://nquiringminds.com
+  name: nqminds
+  behaviour: a86aa19f-a81d-4624-b290-436172a8db1c
+type: d3-device-type-assertion

--- a/d3-cli/tests/test_d3_build.py
+++ b/d3-cli/tests/test_d3_build.py
@@ -181,7 +181,9 @@ def test_inherited_rulename_conflict():
     for json_file in (output_dir).glob("*behaviour.d3.json"):
         with json_file.open() as f:
             data = json.load(f)
-        assert len(data["credentialSubject"]["rules"]) == len(set(rule["name"] for rule in data["credentialSubject"]["rules"]))
+        assert len(data["credentialSubject"]["rules"]) == len(
+            set(rule["name"] for rule in data["credentialSubject"]["rules"])
+        )
 
 
 def test_build():

--- a/d3-cli/tests/test_d3_build.py
+++ b/d3-cli/tests/test_d3_build.py
@@ -182,7 +182,7 @@ def test_inherited_rulename_conflict():
         with json_file.open() as f:
             data = json.load(f)
         assert len(data["credentialSubject"]["rules"]) == len(
-            set(rule["name"] for rule in data["credentialSubject"]["rules"])
+            set(rule["ruleName"] for rule in data["credentialSubject"]["rules"])
         )
 
 

--- a/d3-cli/tests/test_d3_build.py
+++ b/d3-cli/tests/test_d3_build.py
@@ -1,6 +1,6 @@
 import pytest
 from pathlib import Path
-
+import json
 import d3_scripts.d3_build
 
 
@@ -57,7 +57,8 @@ def test_invalid_uri(caplog):
 
 def test_non_existent_parent_behaviour():
     """Test whether behaviours with non-existent parents raises an error"""
-    test_dir = Path(__file__).parent / "__fixtures__" / "non-existent-parent-behaviour"
+    test_dir = Path(__file__).parent / "__fixtures__" / \
+        "non-existent-parent-behaviour"
     output_dir = test_dir / "json"
     with pytest.raises(Exception) as excinfo:
         d3_scripts.d3_build.d3_build(
@@ -71,7 +72,8 @@ def test_non_existent_parent_behaviour():
 
 def test_circular_behaviour_dependencies():
     """Test whether behaviours with circular parent dependencies raise an error"""
-    test_dir = Path(__file__).parent / "__fixtures__" / "circular-type-dependence"
+    test_dir = Path(__file__).parent / "__fixtures__" / \
+        "circular-type-dependence"
     output_dir = test_dir / "json"
     with pytest.raises(Exception) as excinfo:
         d3_scripts.d3_build.d3_build(
@@ -84,7 +86,8 @@ def test_circular_behaviour_dependencies():
 
 def test_non_existent_parent_type():
     """Test whether types with non-existent parents raises an error"""
-    test_dir = Path(__file__).parent / "__fixtures__" / "non-existent-parent-type"
+    test_dir = Path(__file__).parent / "__fixtures__" / \
+        "non-existent-parent-type"
     output_dir = test_dir / "json"
     with pytest.raises(Exception) as excinfo:
         d3_scripts.d3_build.d3_build(
@@ -98,7 +101,8 @@ def test_non_existent_parent_type():
 
 def test_duplicate_property_type_inheritance():
     """Test whether inheriting duplicate properties from types raises an error"""
-    test_dir = Path(__file__).parent / "__fixtures__" / "duplicate-property-type-inheritance"
+    test_dir = Path(__file__).parent / "__fixtures__" / \
+        "duplicate-property-type-inheritance"
     output_dir = test_dir / "json"
     with pytest.raises(Exception) as excinfo:
         d3_scripts.d3_build.d3_build(
@@ -111,7 +115,8 @@ def test_duplicate_property_type_inheritance():
 
 def test_inherit_missing_property():
     """Test whether attempting to inherit missing properties from parent types raises an error"""
-    test_dir = Path(__file__).parent / "__fixtures__" / "missing-property-type-inheritance"
+    test_dir = Path(__file__).parent / "__fixtures__" / \
+        "missing-property-type-inheritance"
     output_dir = test_dir / "json"
     with pytest.raises(Exception) as excinfo:
         d3_scripts.d3_build.d3_build(
@@ -138,7 +143,8 @@ def test_firmware_with_missing_type():
 
 def test_duplicate_property_type_inheritance_single_parent():
     """Test whether inheriting duplicate properties from a single parent type is ignored"""
-    test_dir = Path(__file__).parent / "__fixtures__" / "duplicate-property-type-inheritance-single-parent"
+    test_dir = Path(__file__).parent / "__fixtures__" / \
+        "duplicate-property-type-inheritance-single-parent"
     output_dir = test_dir / "json"
     # should succeed
     d3_scripts.d3_build.d3_build(
@@ -158,6 +164,24 @@ def test_cpe_resoolves():
         output_dir=output_dir,
         skip_mal=True,
     )
+
+
+def test_inherited_rulename_conflict():
+    """Test whether behaviour inheriting a rule with duplicate name to a behaviour rule resolves without duplication"""
+    test_dir = Path(__file__).parent / "__fixtures__" / \
+        "inherited-rulename-conflict"
+    output_dir = test_dir / "json"
+    # should succeed
+    d3_scripts.d3_build.d3_build(
+        d3_folders=[test_dir],
+        output_dir=output_dir,
+        skip_mal=True,
+    )
+    # should not have duplicate rule names
+    for json_file in (output_dir).glob("*behaviour.d3.json"):
+        with json_file.open() as f:
+            data = json.load(f)
+        assert len(data["credentialSubject"]["rules"]) == len(set(rule["name"] for rule in data["credentialSubject"]["rules"]))
 
 
 def test_build():

--- a/d3-cli/tests/test_d3_build.py
+++ b/d3-cli/tests/test_d3_build.py
@@ -57,8 +57,8 @@ def test_invalid_uri(caplog):
 
 def test_non_existent_parent_behaviour():
     """Test whether behaviours with non-existent parents raises an error"""
-    test_dir = Path(__file__).parent / "__fixtures__" / \
-        "non-existent-parent-behaviour"
+    test_dir = (Path(__file__).parent / "__fixtures__" /
+                "non-existent-parent-behaviour")
     output_dir = test_dir / "json"
     with pytest.raises(Exception) as excinfo:
         d3_scripts.d3_build.d3_build(
@@ -72,8 +72,8 @@ def test_non_existent_parent_behaviour():
 
 def test_circular_behaviour_dependencies():
     """Test whether behaviours with circular parent dependencies raise an error"""
-    test_dir = Path(__file__).parent / "__fixtures__" / \
-        "circular-type-dependence"
+    test_dir = (Path(__file__).parent / "__fixtures__" /
+                "circular-type-dependence")
     output_dir = test_dir / "json"
     with pytest.raises(Exception) as excinfo:
         d3_scripts.d3_build.d3_build(
@@ -86,8 +86,8 @@ def test_circular_behaviour_dependencies():
 
 def test_non_existent_parent_type():
     """Test whether types with non-existent parents raises an error"""
-    test_dir = Path(__file__).parent / "__fixtures__" / \
-        "non-existent-parent-type"
+    test_dir = (Path(__file__).parent / "__fixtures__" /
+                "non-existent-parent-type")
     output_dir = test_dir / "json"
     with pytest.raises(Exception) as excinfo:
         d3_scripts.d3_build.d3_build(
@@ -101,8 +101,8 @@ def test_non_existent_parent_type():
 
 def test_duplicate_property_type_inheritance():
     """Test whether inheriting duplicate properties from types raises an error"""
-    test_dir = Path(__file__).parent / "__fixtures__" / \
-        "duplicate-property-type-inheritance"
+    test_dir = (Path(__file__).parent / "__fixtures__" /
+                "duplicate-property-type-inheritance")
     output_dir = test_dir / "json"
     with pytest.raises(Exception) as excinfo:
         d3_scripts.d3_build.d3_build(
@@ -115,8 +115,8 @@ def test_duplicate_property_type_inheritance():
 
 def test_inherit_missing_property():
     """Test whether attempting to inherit missing properties from parent types raises an error"""
-    test_dir = Path(__file__).parent / "__fixtures__" / \
-        "missing-property-type-inheritance"
+    test_dir = (Path(__file__).parent / "__fixtures__" /
+                "missing-property-type-inheritance")
     output_dir = test_dir / "json"
     with pytest.raises(Exception) as excinfo:
         d3_scripts.d3_build.d3_build(
@@ -143,8 +143,8 @@ def test_firmware_with_missing_type():
 
 def test_duplicate_property_type_inheritance_single_parent():
     """Test whether inheriting duplicate properties from a single parent type is ignored"""
-    test_dir = Path(__file__).parent / "__fixtures__" / \
-        "duplicate-property-type-inheritance-single-parent"
+    test_dir = (Path(__file__).parent / "__fixtures__" /
+                "duplicate-property-type-inheritance-single-parent")
     output_dir = test_dir / "json"
     # should succeed
     d3_scripts.d3_build.d3_build(
@@ -168,8 +168,8 @@ def test_cpe_resoolves():
 
 def test_inherited_rulename_conflict():
     """Test whether behaviour inheriting a rule with duplicate name to a behaviour rule resolves without duplication"""
-    test_dir = Path(__file__).parent / "__fixtures__" / \
-        "inherited-rulename-conflict"
+    test_dir = (Path(__file__).parent / "__fixtures__" /
+                "inherited-rulename-conflict")
     output_dir = test_dir / "json"
     # should succeed
     d3_scripts.d3_build.d3_build(

--- a/examples/D3_CORE/dhcp.behaviour.d3.yaml
+++ b/examples/D3_CORE/dhcp.behaviour.d3.yaml
@@ -4,7 +4,7 @@ credentialSubject:
   id: 97c4fb11-5fb8-44c3-b449-107fdbb66a15
   ruleName: Core Rule - DHCP
   rules:
-    - name: dhcp
+    - ruleName: dhcp
       matches:
         eth:
           destinationMac: ff:ff:ff:ff:ff:ff

--- a/examples/behaviour-template.behaviour.d3.yaml
+++ b/examples/behaviour-template.behaviour.d3.yaml
@@ -15,7 +15,7 @@ credentialSubject:
         - from-ipv4-amazonecho-6
   rules:
     # The name key string doesn't need to be unique. It is a brief description of the rule
-    - name: from-ipv4-amazonecho-0
+    - ruleName: from-ipv4-amazonecho-0
       # The matches key contains the protocols that need to be matched (eth, ipv4, tcp and udp)
       matches:
         # The ipv4 protocol match contains the `protocol` number key,
@@ -31,7 +31,7 @@ credentialSubject:
         # The tcp protocol match contains the source-port and destination port
         tcp:
           destinationPort: 443
-    - name: from-ipv4-amazonecho-1
+    - ruleName: from-ipv4-amazonecho-1
       matches:
         ip4:
           protocol: 6
@@ -40,7 +40,7 @@ credentialSubject:
             allowed: true
         tcp:
           destinationPort: 443
-    - name: from-ipv4-amazonecho-2
+    - ruleName: from-ipv4-amazonecho-2
       matches:
         ip4:
           protocol: 17
@@ -49,14 +49,14 @@ credentialSubject:
             allowed: true
         udp:
           destinationPort: 123
-    - name: from-ipv4-amazonecho-3
+    - ruleName: from-ipv4-amazonecho-3
       matches:
         ip4:
           protocol: 2
           destinationIp4:
             addr: 224.0.0.22/32
             allowed: true
-    - name: from-ipv4-amazonecho-4
+    - ruleName: from-ipv4-amazonecho-4
       matches:
         ip4:
           protocol: 17
@@ -65,7 +65,7 @@ credentialSubject:
             allowed: true
         udp:
           destinationPort: 1900
-    - name: from-ipv4-amazonecho-5
+    - ruleName: from-ipv4-amazonecho-5
       matches:
         eth:
           destinationMac: ff:ff:ff:ff:ff:ff
@@ -78,7 +78,7 @@ credentialSubject:
             allowed: true
         udp:
           destinationPort: 67
-    - name: from-ipv4-amazonecho-6
+    - ruleName: from-ipv4-amazonecho-6
       matches:
         eth:
           destinationMac: ff:ff:ff:ff:ff:ff
@@ -91,7 +91,7 @@ credentialSubject:
             allowed: true
         udp:
           destinationPort: 67
-    - name: from-ipv4-amazonecho-7
+    - ruleName: from-ipv4-amazonecho-7
       matches:
         ip4:
           protocol: 17
@@ -100,7 +100,7 @@ credentialSubject:
             allowed: true
         udp:
           destinationPort: 53
-    - name: from-malicious-sender
+    - ruleName: from-malicious-sender
       malicious: True
       matches:
         ip4:

--- a/examples/manufacturers/Amazon/Echo-dot/behaviours/echo-dot-v2.behaviour.d3.yaml
+++ b/examples/manufacturers/Amazon/Echo-dot/behaviours/echo-dot-v2.behaviour.d3.yaml
@@ -10,7 +10,7 @@ credentialSubject:
   parents:
     - fc4d5a51-f985-4de1-a157-51ea9ca5e9c0 # Id of parent behaviour to inherit from
 rules:
-    - name: firmware-rule-1
+    - ruleName: firmware-rule-1
       # The matches key contains the protocols that need to be matched (eth, ipv4, tcp and udp)
       matches:
         ip4:

--- a/examples/manufacturers/Amazon/Echo/echo.behaviour.d3.yaml
+++ b/examples/manufacturers/Amazon/Echo/echo.behaviour.d3.yaml
@@ -8,7 +8,7 @@ credentialSubject:
   ruleName: "Amazon Echo"
   rules:
     # The name key string doesn't need to be unique. It is a brief description of the rule
-    - name: from-ipv4-amazonecho-0
+    - ruleName: from-ipv4-amazonecho-0
       # The matches key contains the protocols that need to be matched (eth, ipv4, tcp and udp)
       matches:
         # The ipv4 protocol match contains the `protocol` number key,
@@ -23,7 +23,7 @@ credentialSubject:
         # The tcp protocol match contains the source-port and destination port
         tcp:
           destinationPort: 443
-    - name: from-ipv4-amazonecho-1
+    - ruleName: from-ipv4-amazonecho-1
       matches:
         ip4:
           protocol: 6
@@ -31,7 +31,7 @@ credentialSubject:
             addr: softwareupdates.amazon.com
         tcp:
           destinationPort: 443
-    - name: from-ipv4-amazonecho-2
+    - ruleName: from-ipv4-amazonecho-2
       matches:
         ip4:
           protocol: 17
@@ -39,13 +39,13 @@ credentialSubject:
             addr: 3.north-america.pool.ntp.org
         udp:
           destinationPort: 123
-    - name: from-ipv4-amazonecho-3
+    - ruleName: from-ipv4-amazonecho-3
       matches:
         ip4:
           protocol: 2
           destinationIp4:
             addr: 224.0.0.22/32
-    - name: from-ipv4-amazonecho-4
+    - ruleName: from-ipv4-amazonecho-4
       matches:
         ip4:
           protocol: 17
@@ -53,7 +53,7 @@ credentialSubject:
             addr: 239.255.255.250/32
         udp:
           destinationPort: 1900
-    - name: from-ipv4-amazonecho-5
+    - ruleName: from-ipv4-amazonecho-5
       matches:
         eth:
           destinationMac: ff:ff:ff:ff:ff:ff
@@ -65,7 +65,7 @@ credentialSubject:
             addr: 255.255.255.255/32
         udp:
           destinationPort: 67
-    - name: from-ipv4-amazonecho-6
+    - ruleName: from-ipv4-amazonecho-6
       matches:
         eth:
           destinationMac: ff:ff:ff:ff:ff:ff
@@ -77,7 +77,7 @@ credentialSubject:
             addr: 255.255.255.255/32
         udp:
           destinationPort: 67
-    - name: from-ipv4-amazonecho-7
+    - ruleName: from-ipv4-amazonecho-7
       matches:
         ip4:
           protocol: 17

--- a/examples/manufacturers_2/CocaCola/Cooler/cooler.behaviour.d3.yaml
+++ b/examples/manufacturers_2/CocaCola/Cooler/cooler.behaviour.d3.yaml
@@ -8,7 +8,7 @@ credentialSubject:
   ruleName: "Amazon Echo"
   rules:
     # The name key string doesn't need to be unique. It is a brief description of the rule
-    - name: from-ipv4-amazonecho-0
+    - ruleName: from-ipv4-amazonecho-0
       # The matches key contains the protocols that need to be matched (eth, ipv4, tcp and udp)
       matches:
         # The ipv4 protocol match contains the `protocol` number key,
@@ -24,7 +24,7 @@ credentialSubject:
         # The tcp protocol match contains the source-port and destination port
         tcp:
           destinationPort: 443
-    - name: from-ipv4-amazonecho-1
+    - ruleName: from-ipv4-amazonecho-1
       matches:
         ip4:
           protocol: 6
@@ -33,7 +33,7 @@ credentialSubject:
             allowed: true
         tcp:
           destinationPort: 443
-    - name: from-ipv4-amazonecho-2
+    - ruleName: from-ipv4-amazonecho-2
       matches:
         ip4:
           protocol: 17
@@ -42,14 +42,14 @@ credentialSubject:
             allowed: true
         udp:
           destinationPort: 123
-    - name: from-ipv4-amazonecho-3
+    - ruleName: from-ipv4-amazonecho-3
       matches:
         ip4:
           protocol: 2
           destinationIp4:
             addr: 224.0.0.22/32
             allowed: true
-    - name: from-ipv4-amazonecho-4
+    - ruleName: from-ipv4-amazonecho-4
       matches:
         ip4:
           protocol: 17
@@ -58,7 +58,7 @@ credentialSubject:
             allowed: true
         udp:
           destinationPort: 1900
-    - name: from-ipv4-amazonecho-5
+    - ruleName: from-ipv4-amazonecho-5
       matches:
         eth:
           destinationMac: ff:ff:ff:ff:ff:ff
@@ -71,7 +71,7 @@ credentialSubject:
             allowed: true
         udp:
           destinationPort: 67
-    - name: from-ipv4-amazonecho-6
+    - ruleName: from-ipv4-amazonecho-6
       matches:
         eth:
           destinationMac: ff:ff:ff:ff:ff:ff
@@ -84,7 +84,7 @@ credentialSubject:
             allowed: true
         udp:
           destinationPort: 67
-    - name: from-ipv4-amazonecho-7
+    - ruleName: from-ipv4-amazonecho-7
       matches:
         ip4:
           protocol: 17


### PR DESCRIPTION
Check if inherited name already exists in aggregated rules, if it does prepend the rule's ruleName with the parent ruleName. 

Also fix a schema mismatch with the manySecured app where each rule's name was defined with the variable 'name' instead of 'ruleName'.

fixes https://github.com/TechWorksHub/ManySecured-D3DB/issues/67

